### PR TITLE
refactor: update logger import path and sync dependencies with tinhti…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/go-redsync/redsync/v4 v4.14.0
-	github.com/redis/go-redis/v9 v9.14.1
+	github.com/go-redsync/redsync/v4 v4.15.0
+	github.com/redis/go-redis/v9 v9.17.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
-	github.com/tinh-tinh/tinhtinh/v2 v2.3.4
+	github.com/tinh-tinh/tinhtinh/v2 v2.5.0
 	golang.org/x/crypto v0.45.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-redsync/redsync/v4 v4.14.0 h1:zyxzFJsmQHIPBl8iBT7KFKohWsjsghgGLiP8TnFMLNc=
 github.com/go-redsync/redsync/v4 v4.14.0/go.mod h1:twMlVd19upZ/juvJyJGlQOSQxor1oeHtjs62l4pRFzo=
+github.com/go-redsync/redsync/v4 v4.15.0 h1:KH/XymuxSV7vyKs6z1Cxxj+N+N18JlPxgXeP6x4JY54=
+github.com/go-redsync/redsync/v4 v4.15.0/go.mod h1:qNp+lLs3vkfZbtA/aM/OjlZHfEr5YTAYhRktFPKHC7s=
 github.com/gomodule/redigo v1.9.2 h1:HrutZBLhSIU8abiSfW8pj8mPhOyMYjZT/wcA4/L9L9s=
 github.com/gomodule/redigo v1.9.2/go.mod h1:KsU3hiK/Ay8U42qpaJk+kuNa3C+spxapWpM+ywhcgtw=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -27,6 +29,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.14.1 h1:nDCrEiJmfOWhD76xlaw+HXT0c9hfNWeXgl0vIRYSDvQ=
 github.com/redis/go-redis/v9 v9.14.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+github.com/redis/go-redis/v9 v9.17.2 h1:P2EGsA4qVIM3Pp+aPocCJ7DguDHhqrXNhVcEp4ViluI=
+github.com/redis/go-redis/v9 v9.17.2/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/redis/rueidis v1.0.64 h1:XqgbueDuNV3qFdVdQwAHJl1uNt90zUuAJuzqjH4cw6Y=
 github.com/redis/rueidis v1.0.64/go.mod h1:Lkhr2QTgcoYBhxARU7kJRO8SyVlgUuEkcJO1Y8MCluA=
 github.com/redis/rueidis/rueidiscompat v1.0.64 h1:M8JbLP4LyHQhBLBRsUQIzui8/LyTtdESNIMVveqm4RY=
@@ -39,6 +43,8 @@ github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08Yu
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
 github.com/tinh-tinh/tinhtinh/v2 v2.3.4 h1:vxhaoPnp3pGNcdXKDG7nVai+V+lYoJHWtm7pzTNapJY=
 github.com/tinh-tinh/tinhtinh/v2 v2.3.4/go.mod h1:4nppE7KAIswZKutI9ElMqAD9kyash7aea0Ewowsqj5g=
+github.com/tinh-tinh/tinhtinh/v2 v2.5.0 h1:SqCanZJKKgbVsDwoaPe136fZGYoXSKZ6fLciGO0KsoY=
+github.com/tinh-tinh/tinhtinh/v2 v2.5.0/go.mod h1:4nppE7KAIswZKutI9ElMqAD9kyash7aea0Ewowsqj5g=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=

--- a/queue.go
+++ b/queue.go
@@ -15,7 +15,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/robfig/cron/v3"
 	"github.com/tinh-tinh/tinhtinh/v2/common"
-	"github.com/tinh-tinh/tinhtinh/v2/middleware/logger"
+	"github.com/tinh-tinh/tinhtinh/v2/common/logger"
 )
 
 type JobFnc func(job *Job)
@@ -141,10 +141,10 @@ func (q *Queue) BulkAddJob(options []AddJobOptions) {
 		q.Run()
 		return
 	}
-	
+
 	// Sort input options by priority once
 	sort.SliceStable(options, func(i, j int) bool { return options[i].Priority > options[j].Priority })
-	
+
 	// Pre-allocate space for new jobs
 	newJobs := make([]Job, 0, len(options))
 	for _, option := range options {
@@ -158,7 +158,7 @@ func (q *Queue) BulkAddJob(options []AddJobOptions) {
 		}
 		newJobs = append(newJobs, *job)
 	}
-	
+
 	// Merge sorted slices efficiently
 	q.jobs = mergeSortedJobs(q.jobs, newJobs)
 	q.Run()
@@ -168,7 +168,7 @@ func (q *Queue) BulkAddJob(options []AddJobOptions) {
 func mergeSortedJobs(jobs1, jobs2 []Job) []Job {
 	result := make([]Job, 0, len(jobs1)+len(jobs2))
 	i, j := 0, 0
-	
+
 	for i < len(jobs1) && j < len(jobs2) {
 		if jobs1[i].Priority >= jobs2[j].Priority {
 			result = append(result, jobs1[i])
@@ -178,7 +178,7 @@ func mergeSortedJobs(jobs1, jobs2 []Job) []Job {
 			j++
 		}
 	}
-	
+
 	result = append(result, jobs1[i:]...)
 	result = append(result, jobs2[j:]...)
 	return result


### PR DESCRIPTION
…nh v2.5.0

- Change logger import from middleware/logger to common/logger
- Update tinhtinh/v2 dependency from v2.3.4 to v2.5.0
- Update go-redsync from v4.14.0 to v4.15.0
- Update go-redis from v9.14.1 to v9.17.2
- Remove trailing whitespace in queue.go